### PR TITLE
feat: allow overwrite of origin

### DIFF
--- a/bin/deploy.mjs
+++ b/bin/deploy.mjs
@@ -28,8 +28,8 @@ if (!WSK_AUTH || !WSK_NAMESPACE) {
 const [, , zipFilePath, givenName] = process.argv;
 const [packageName, actionName] = givenName?.split('/') || [];
 
-const resolvedZipFilePath = path.resolve(zipFilePath);
-const zipFileExists = fs.existsSync(resolvedZipFilePath);
+const resolvedZipFilePath = zipFilePath && path.resolve(zipFilePath);
+const zipFileExists = zipFilePath && fs.existsSync(resolvedZipFilePath);
 
 if (!packageName || !actionName || !zipFileExists) {
   if (!zipFileExists) {


### PR DESCRIPTION
- allows to overwrite the origin defined in the converter.yaml with a param of the action/package
- the is useful for customers where the runtime function uses the author but local development happens on publish due to lack of permissions 