### PR TITLE
Add support for LOGIN_TOKEN environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/*
 **/node_modules/**
 **/dist/**
 .env
+.node-version

--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ For use case where the origin requires authorization it is possible to specify t
 1.  Add a `Authorization` header to the request using a browser extension. The header will be passed through to the origin.
 2. Set `AEM_USER` and `AEM_PASSWORD` environment variables to add a basic `Authorization` header to the origin request.
 3. Set a `AEM_TOKEN` environment variable to add a bearer `Authorization` header to the origin request.
+4. Set a `LOGIN_TOKEN` environment variable to add a `login-token` cookie to the origin request.
 
-For (2) and (3) it is possible to create a `.env` file in the project root with the environment variables which will be read with using [dotenv/config](https://github.com/motdotla/dotenv) when starting the converter.
+For  the options (2),(3) and (4) it is possible to create a `.env` file in the project root with the environment variables which will be read with using [dotenv/config](https://github.com/motdotla/dotenv) when starting the converter.
 
 ## Implementation Details 
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For use case where the origin requires authorization it is possible to specify t
 1.  Add a `Authorization` header to the request using a browser extension. The header will be passed through to the origin.
 2. Set `AEM_USER` and `AEM_PASSWORD` environment variables to add a basic `Authorization` header to the origin request.
 3. Set a `AEM_TOKEN` environment variable to add a bearer `Authorization` header to the origin request.
-4. Set a `LOGIN_TOKEN` environment variable to add a `login-token` cookie to the origin request.
+4. Set a `AEM_LOGIN_TOKEN` environment variable to add a `login-token` cookie to the origin request.
 
 For  the options (2),(3) and (4) it is possible to create a `.env` file in the project root with the environment variables which will be read with using [dotenv/config](https://github.com/motdotla/dotenv) when starting the converter.
 

--- a/src/steps/fetch-content.js
+++ b/src/steps/fetch-content.js
@@ -16,7 +16,7 @@ import { isBinary } from '../util/media-utils.js';
 
 export default async function fetchContent(state, params, opts) {
   const { path, queryString } = state;
-  const { authorization, cookie } = params;
+  const { authorization, loginToken } = params;
   const { converterCfg, mappingCfg } = opts;
   const { origin, suffix } = converterCfg || {};
 
@@ -38,8 +38,8 @@ export default async function fetchContent(state, params, opts) {
   const requestHeaders = { 'cache-control': 'no-cache' };
   if (authorization) {
     requestHeaders.authorization = authorization;
-  } else if (cookie) {
-    requestHeaders.cookie = cookie;
+  } else if (loginToken) {
+    requestHeaders.cookie = loginToken;
   }
 
   const resp = await fetch(originUrl, { headers: { ...requestHeaders } });

--- a/src/steps/fetch-content.js
+++ b/src/steps/fetch-content.js
@@ -16,7 +16,7 @@ import { isBinary } from '../util/media-utils.js';
 
 export default async function fetchContent(state, params, opts) {
   const { path, queryString } = state;
-  const { authorization } = params;
+  const { authorization, cookie } = params;
   const { converterCfg, mappingCfg } = opts;
   const { origin, suffix } = converterCfg || {};
 
@@ -38,6 +38,8 @@ export default async function fetchContent(state, params, opts) {
   const requestHeaders = { 'cache-control': 'no-cache' };
   if (authorization) {
     requestHeaders.authorization = authorization;
+  } else if (cookie) {
+    requestHeaders.cookie = cookie;
   }
 
   const resp = await fetch(originUrl, { headers: { ...requestHeaders } });

--- a/src/wrapper/express.js
+++ b/src/wrapper/express.js
@@ -29,7 +29,7 @@ import { toBuffer } from '../steps/blob-encode.js';
 import originalMd2Html from '../steps/md2html.js';
 
 const {
-  AEM_USER, AEM_PASSWORD, AEM_TOKEN, LOGIN_TOKEN,
+  AEM_USER, AEM_PASSWORD, AEM_TOKEN, AEM_LOGIN_TOKEN,
 } = process.env;
 const LOCALHOST = 'http://127.0.0.1';
 const CACHE = {};
@@ -202,8 +202,8 @@ export function toExpress(pipe, opts = {}) {
         requestHeaders.authorization = `Bearer ${AEM_TOKEN}`;
       } else if (AEM_USER && AEM_PASSWORD) {
         requestHeaders.authorization = `Basic ${Buffer.from(`${AEM_USER}:${AEM_PASSWORD}`).toString('base64')}`;
-      } else if (LOGIN_TOKEN) {
-        requestHeaders.cookie = `login-token=${LOGIN_TOKEN}`;
+      } else if (AEM_LOGIN_TOKEN) {
+        params.loginToken = `login-token=${AEM_LOGIN_TOKEN}`;
       }
     }
 

--- a/src/wrapper/express.js
+++ b/src/wrapper/express.js
@@ -28,7 +28,9 @@ import { isBinary } from '../util/media-utils.js';
 import { toBuffer } from '../steps/blob-encode.js';
 import originalMd2Html from '../steps/md2html.js';
 
-const { AEM_USER, AEM_PASSWORD, AEM_TOKEN } = process.env;
+const {
+  AEM_USER, AEM_PASSWORD, AEM_TOKEN, LOGIN_TOKEN,
+} = process.env;
 const LOCALHOST = 'http://127.0.0.1';
 const CACHE = {};
 
@@ -200,6 +202,8 @@ export function toExpress(pipe, opts = {}) {
         requestHeaders.authorization = `Bearer ${AEM_TOKEN}`;
       } else if (AEM_USER && AEM_PASSWORD) {
         requestHeaders.authorization = `Basic ${Buffer.from(`${AEM_USER}:${AEM_PASSWORD}`).toString('base64')}`;
+      } else if (LOGIN_TOKEN) {
+        requestHeaders.cookie = `login-token=${LOGIN_TOKEN}`;
       }
     }
 

--- a/src/wrapper/runtime.js
+++ b/src/wrapper/runtime.js
@@ -27,6 +27,7 @@ export function toRuntime(pipe, opts = {}) {
     } = process.env;
     const queryString = params.__ow_query;
     const authorization = params.__ow_headers ? params.__ow_headers.authorization : '';
+    const cookie = params.__ow_headers ? params.__ow_headers.cookie : '';
     let path = params.__ow_path;
 
     if (path.endsWith('.md')) {
@@ -93,7 +94,7 @@ export function toRuntime(pipe, opts = {}) {
         error, blob, html, md, contentType,
       } = await pipe.run(
         { path, queryString },
-        { ...params, authorization },
+        { ...params, authorization, cookie },
         opts,
       );
       const statusCode = error?.code || 200;

--- a/src/wrapper/runtime.js
+++ b/src/wrapper/runtime.js
@@ -27,7 +27,6 @@ export function toRuntime(pipe, opts = {}) {
     } = process.env;
     const queryString = params.__ow_query;
     const authorization = params.__ow_headers ? params.__ow_headers.authorization : '';
-    const cookie = params.__ow_headers ? params.__ow_headers.cookie : '';
     let path = params.__ow_path;
 
     if (path.endsWith('.md')) {
@@ -94,7 +93,7 @@ export function toRuntime(pipe, opts = {}) {
         error, blob, html, md, contentType,
       } = await pipe.run(
         { path, queryString },
-        { ...params, authorization, cookie },
+        { ...params, authorization },
         opts,
       );
       const statusCode = error?.code || 200;


### PR DESCRIPTION
This pull request adds support for the LOGIN_TOKEN environment variable, which allows the addition of a `login-token` cookie to the origin request. This provides an additional option for authorization when making requests to the origin.