### PR TITLE
Reversing the mappings breaks when the configuration is global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/*
 **/dist/**
 .env
 .node-version
+.idea/

--- a/src/util/mapping.js
+++ b/src/util/mapping.js
@@ -79,7 +79,7 @@ export function mapInbound(franklinPath, cfg) {
 
     // test the path without extension, and the original path
     const candidates = [path, originalPath];
-    const reversedMappings = cfg.mappings.reverse();
+    const reversedMappings = structuredClone(cfg.mappings).reverse();
 
     for (const mapping of reversedMappings) {
       const [aemBasePath, franklinBasePath] = mapping.split(':', 2);
@@ -129,7 +129,7 @@ export function mapOutbound(aemPath, cfg) {
 
     // test the path without extension, and the original path
     const candidates = [path, originalPath];
-    const reversedMappings = cfg.mappings.reverse();
+    const reversedMappings = structuredClone(cfg.mappings).reverse();
 
     for (const mapping of reversedMappings) {
       const [from, to] = mapping.split(':', 2);

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -16,7 +16,7 @@ import { mapInbound, mapOutbound } from '../src/util/mapping.js';
 describe('Mapping', () => {
   describe('map inbound', () => {
     [
-      ['/content/site/us/en/page:/vanity', '/vanity.html', '/content/site/us/en/page.html'],
+      ['/content/site/us/en/page:/vanity,', '/vanity.html', '/content/site/us/en/page.html'],
       ['/content/site/us/en/page:/vanity', '/vanity-bar.html', '/vanity-bar.html'],
       ['/content/site/ch/en:/en-ch/', '/en-ch/index.html', '/content/site/ch/en.html'],
       // folder to single page is ignored
@@ -46,6 +46,14 @@ describe('Mapping', () => {
       ['/site/header.json:/.helix/headers.json', '/.helix/headers.json', '/site/header.json'],
     ].forEach(([mapping, from, to]) => {
       it(`${mapping} maps ${from} to ${to}`, () => assert.equal(to, mapInbound(from, { mappings: mapping.split(',') })));
+    });
+
+    [
+      ['/content/wknd/:/,/content/experience-fragments/wknd/:/fragments/,/api/assets/:/content/dam/,', '/content/dam/wknd/content-fragments/author.json', '/api/assets/wknd/content-fragments/author.json'],
+    ].forEach(([mapping, from, to]) => {
+      const cfg = { mappings: mapping.split(',') };
+      it(`${mapping} maps ${from} to ${to} for the first time `, () => assert.equal(to, mapInbound(from, cfg)));
+      it(`${mapping} maps ${from} to ${to} for the second time`, () => assert.equal(to, mapInbound(from, cfg)));
     });
 
     // overlapping mappings

--- a/test/pipe.test.js
+++ b/test/pipe.test.js
@@ -12,8 +12,8 @@
 
 /* eslint-disable no-unused-vars */
 
-import { pipe } from '../src/util/pipe.js';
 import assert from 'assert';
+import { pipe } from '../src/util/pipe.js';
 
 describe('Pipe', () => {
   it('runs each step after another', async () => {


### PR DESCRIPTION
Using `reverse()` on the mappings introduced a undesired behaviour when the mappings is actually shared. This pr fixes that by cloning the mappins before reversing it - tests have been added as well.