### PR TITLE
Fix: Handling sendRes in case of wrapper error object

### DIFF
--- a/src/wrapper/express.js
+++ b/src/wrapper/express.js
@@ -253,10 +253,12 @@ export function toExpress(pipe, opts = {}) {
       const { originalUrl, protocol } = req;
       const reqUrl = new URL(`${protocol}://${req.get('host')}${originalUrl}`);
       const queryString = reqUrl.search.substring(1);
-      const sendRes = ({ statusCode, body, headers }) => {
-        res.set({ ...headers, 'cache-control': 'privat, max-age=300' });
-        res.status(statusCode);
-        res.send(body);
+      const sendRes = (state) => {
+        // Handling in case of nested error object
+        if (Object.hasOwn(state, 'error')) state = state.error;
+        res.set({ ...state.headers, 'cache-control': 'privat, max-age=300' });
+        res.status(state.statusCode);
+        res.send(state.body);
       };
 
       // check if the file was already served

--- a/src/wrapper/express.js
+++ b/src/wrapper/express.js
@@ -255,8 +255,9 @@ export function toExpress(pipe, opts = {}) {
       const queryString = reqUrl.search.substring(1);
       const sendRes = (state) => {
         // Handling in case of nested error object
-        if (Object.hasOwn(state,'error') && Object.keys(state).length === 1)
+        if (Object.hasOwn(state, 'error') && Object.keys(state).length === 1) {
           state = state.error;
+        }
         res.set({ ...state.headers, 'cache-control': 'privat, max-age=300' });
         res.status(state.statusCode);
         res.send(state.body);

--- a/src/wrapper/express.js
+++ b/src/wrapper/express.js
@@ -255,7 +255,8 @@ export function toExpress(pipe, opts = {}) {
       const queryString = reqUrl.search.substring(1);
       const sendRes = (state) => {
         // Handling in case of nested error object
-        if (Object.hasOwn(state, 'error')) state = state.error;
+        if (Object.hasOwn(state,'error') && Object.keys(state).length === 1)
+          state = state.error;
         res.set({ ...state.headers, 'cache-control': 'privat, max-age=300' });
         res.status(state.statusCode);
         res.send(state.body);


### PR DESCRIPTION
This PR handles the `sendRes` function in scenarios where we get non 200 responses from `runtime.js` https://github.com/buuhuu/crosswalk-converter/blob/4e0db530d01150155bf6511f2fca95d16de74bec/src/wrapper/runtime.js#L100-L107
Since from here we are returning a wrapper object and other times we have the `state` object which directly has required properties